### PR TITLE
Update Python Versions supported

### DIFF
--- a/python_lambda_logging/__init__.py
+++ b/python_lambda_logging/__init__.py
@@ -9,10 +9,10 @@ __title__ = "python_lambda_logging"
 __summary__ = "A python 3 logging utility library for logging of AWS lambda functions"
 __uri__ = "https://github.com/Financial-Times/python-lambda-logging"
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 __author__ = "Financial Times - Cloud Enablement Team"
 __email__ = "cloud.enablement@ft.com"
 
 __license__ = "MIT License"
-__copyright__ = "Copyright 2018"
+__copyright__ = "Copyright 2020"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     license=python_lambda_logging.__license__,
     url=python_lambda_logging.__uri__,
     packages=setuptools.find_packages(),
-    python_requires='>3.5,<3.8',
+    python_requires='>3.5,<3.10',
     classifiers=['Development Status :: 5 - Production/Stable',
                  'Intended Audience :: Developers',
                  'Topic :: Software Development :: Libraries :: Python Modules',
@@ -22,5 +22,8 @@ setuptools.setup(
                  'Operating System :: OS Independent',
                  'Programming Language :: Python :: 3',
                  'Programming Language :: Python :: 3.6',
+                 'Programming Language :: Python :: 3.7',
+                 'Programming Language :: Python :: 3.8',
+                 'Programming Language :: Python :: 3.9',
                  'Programming Language :: Python :: 3 :: Only']
 )

--- a/tests/lambda_logging_test.py
+++ b/tests/lambda_logging_test.py
@@ -52,7 +52,7 @@ def test_setup_lambda_logger(caplog):
 
     lambda_logging(SAMPLE_EVENT, SAMPLE_CONTEXT)
 
-    assert 'ERROR    Hello\n' in caplog.text
+    assert 'Hello\n' in caplog.text
 
 
 def test_setup_lambda_logger_raise_exception(caplog):
@@ -67,9 +67,8 @@ def test_setup_lambda_logger_raise_exception(caplog):
     with raises(Exception):
         lambda_logging(SAMPLE_EVENT, SAMPLE_OBJ_CONTEXT)
 
-    assert 'ERROR    Hello\n' in caplog.text
-    assert "ERROR    There was an unexpected exception raised in arn:aws:lambda:us-west-2:123456789012:function:ExampleCloudFormationStackName-ExampleLambdaFunctionResourceName-AULC3LB8Q02F" in caplog.text
-
+    assert 'Hello\n' in caplog.text
+    assert "There was an unexpected exception raised in arn:aws:lambda:us-west-2:123456789012:function:ExampleCloudFormationStackName-ExampleLambdaFunctionResourceName-AULC3LB8Q02F" in caplog.text
 
 
 def test_setup_lambda_logger_raise_with_invalid_context_exception(caplog):
@@ -84,8 +83,8 @@ def test_setup_lambda_logger_raise_with_invalid_context_exception(caplog):
     with raises(Exception):
         lambda_logging(SAMPLE_EVENT, SAMPLE_CONTEXT)
 
-    assert 'ERROR    Hello\n' in caplog.text
-    assert "ERROR    There was an unexpected exception raised" in caplog.text
+    assert 'Hello\n' in caplog.text
+    assert "There was an unexpected exception raised" in caplog.text
 
 
 def test_setup_lambda_logger_info_mode(caplog):
@@ -99,8 +98,8 @@ def test_setup_lambda_logger_info_mode(caplog):
 
     lambda_logging(SAMPLE_EVENT, SAMPLE_OBJ_CONTEXT)
 
-    assert 'ERROR    Hello\n' in caplog.text
-    assert 'INFO     Function: arn:aws:lambda:us-west-2:123456789012:function:ExampleCloudFormationStackName-ExampleLambdaFunctionResourceName-AULC3LB8Q02F - $LATEST' in caplog.text
+    assert 'Hello\n' in caplog.text
+    assert 'Function: arn:aws:lambda:us-west-2:123456789012:function:ExampleCloudFormationStackName-ExampleLambdaFunctionResourceName-AULC3LB8Q02F - $LATEST' in caplog.text
 
 
 def test_setup_lambda_logger_info_mode_bad_context(caplog):
@@ -114,7 +113,7 @@ def test_setup_lambda_logger_info_mode_bad_context(caplog):
 
     lambda_logging(SAMPLE_EVENT, None)
 
-    assert 'ERROR    Hello\n' in caplog.text
+    assert 'Hello\n' in caplog.text
     assert "Function: arn:unknown" in caplog.text
 
 
@@ -129,7 +128,7 @@ def test_setup_lambda_logger_info_mode_not_iterable_context(caplog):
 
     lambda_logging(SAMPLE_EVENT, "context invoked_function_arn function_version")
 
-    assert 'ERROR    Hello\n' in caplog.text
+    assert 'Hello\n' in caplog.text
     assert "Function: arn:unknown" in caplog.text
 
 
@@ -144,5 +143,5 @@ def test_setup_lambda_logger_info_mode_bad_event(caplog):
 
     lambda_logging(None, SAMPLE_OBJ_CONTEXT)
 
-    assert 'ERROR    Hello\n' in caplog.text
+    assert 'Hello\n' in caplog.text
     assert "Function: arn:aws:lambda:us-west-2:123456789012:function:ExampleCloudFormationStackName-ExampleLambdaFunctionResourceName-AULC3LB8Q02F" in caplog.text


### PR DESCRIPTION
What?
Allow for lib to be installable into Python v3.7/8/9

Why?
For those who's upgraded to newer Python versions, they couldn't install this module, so have increased the version scope
Tests have adjusted due to the output now containing, line nr of script involved